### PR TITLE
canmonitor: fix behaviour when user resizes window

### DIFF
--- a/canmonitor.py
+++ b/canmonitor.py
@@ -164,6 +164,7 @@ def main(stdscr, serial_thread):
             break
         elif c == curses.KEY_RESIZE:
             win = init_window(stdscr)
+            should_redraw.set()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process CAN data from a serial device.')


### PR DESCRIPTION
Previously, if the user resized the window, all information vanished from the
screen and only came back when the next message was read.

Now the whole window content is redrawn just after user has resized the window.