### PR TITLE
Fix upgrade to python3

### DIFF
--- a/canmonitor/canmonitor.py
+++ b/canmonitor/canmonitor.py
@@ -20,7 +20,7 @@ thread_exception = None
 def read_until_newline(serial_device):
     """Read data from `serial_device` until the next newline character."""
     line = serial_device.readline()
-    while len(line) == 0 or line[-1:] != b'\n':
+    while not line.endswith(b'\n'):
         line = line + serial_device.readline()
 
     return line.strip()

--- a/canmonitor/canmonitor.py
+++ b/canmonitor/canmonitor.py
@@ -20,7 +20,7 @@ thread_exception = None
 def read_until_newline(serial_device):
     """Read data from `serial_device` until the next newline character."""
     line = serial_device.readline()
-    while len(line) == 0 or line[-1] != '\n':
+    while len(line) == 0 or line[-1:] != b'\n':
         line = line + serial_device.readline()
 
     return line.strip()
@@ -34,7 +34,7 @@ def serial_run_loop(serial_device, blacklist):
 
             # Sample frame from Arduino: FRAME:ID=246:LEN=8:8E:62:1C:F6:1E:63:63:20
             # Split it into an array (e.g. ['FRAME', 'ID=246', 'LEN=8', '8E', '62', '1C', 'F6', '1E', '63', '63', '20'])
-            frame = line.split(':')
+            frame = line.split(b':')
 
             try:
                 frame_id = int(frame[1][3:])  # get the ID from the 'ID=246' string

--- a/canmonitor/canmonitor.py
+++ b/canmonitor/canmonitor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from binascii import unhexlify
 import curses
 import sys
 import threading
@@ -33,8 +34,8 @@ def serial_run_loop(serial_device, blacklist):
             line = read_until_newline(serial_device)
 
             # Sample frame from Arduino: FRAME:ID=246:LEN=8:8E:62:1C:F6:1E:63:63:20
-            # Split it into an array (e.g. ['FRAME', 'ID=246', 'LEN=8', '8E', '62', '1C', 'F6', '1E', '63', '63', '20'])
-            frame = line.split(b':')
+            # Split it into an array (e.g. ['FRAME', 'ID=246', 'LEN=8', '8E:62:1C:F6:1E:63:63:20'])
+            frame = line.split(b':', maxsplit=3)
 
             try:
                 frame_id = int(frame[1][3:])  # get the ID from the 'ID=246' string
@@ -44,8 +45,8 @@ def serial_run_loop(serial_device, blacklist):
 
                 frame_length = int(frame[2][4:])  # get the length from the 'LEN=8' string
 
-                data = [int(byte, 16) for byte in frame[3:]]  # convert the hex strings array to an integer array
-                data = [byte for byte in data if byte >= 0 and byte <= 255]  # sanity check
+                hex_data = frame[3].replace(b':', b'')
+                data = unhexlify(hex_data)
 
                 if len(data) != frame_length:
                     # Wrong frame length or invalid data

--- a/tests/test_canmonitor.py
+++ b/tests/test_canmonitor.py
@@ -4,6 +4,8 @@
 from os import path
 import unittest
 
+import serial
+
 from canmonitor import canmonitor
 
 
@@ -43,3 +45,15 @@ class CanmonitorTestCase(unittest.TestCase):
             int_set = canmonitor.parse_ints(f_obj)
         self.assertEqual(int_set, {1, 2, 15, 3, 4, 57, 7})
 
+    def test_read_until_newline(self):
+        ser = serial.serial_for_url('loop://')
+
+        sent_msg = b'hello'
+
+        try:
+            ser.write(sent_msg + b'\n')
+
+            read_msg = canmonitor.read_until_newline(ser)
+            self.assertEqual(sent_msg, read_msg)
+        finally:
+            ser.close()


### PR DESCRIPTION
- Fix bug caused by upgrade to python3
- Store can data as bytes (new in python3)

The upgrade to python3 introduced a bug which made it impossible to read anything.
Because when used in python3, pyserial's `readline` returns bytes, while it used to return a string. So `canmonitor.read_until_newline` would never return.

Also, python3 makes it possible to store can data as bytes rather than integer array.